### PR TITLE
Add StatusEntrega enum and refactor status fields

### DIFF
--- a/src/main/java/com/unifood/entregador/dto/AtribuirEntregaResponse.java
+++ b/src/main/java/com/unifood/entregador/dto/AtribuirEntregaResponse.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.unifood.entregador.model.StatusEntrega;
+
 @Getter
 @Setter
 @AllArgsConstructor
 public class AtribuirEntregaResponse {
     private Long entregaId;
     private Long entregadorId;
-    private String status;
+    private StatusEntrega status;
 }

--- a/src/main/java/com/unifood/entregador/dto/AtualizarStatusEntregaRequest.java
+++ b/src/main/java/com/unifood/entregador/dto/AtualizarStatusEntregaRequest.java
@@ -3,8 +3,10 @@ package com.unifood.entregador.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.unifood.entregador.model.StatusEntrega;
+
 @Getter
 @Setter
 public class AtualizarStatusEntregaRequest {
-    private String status;
+    private StatusEntrega status;
 }

--- a/src/main/java/com/unifood/entregador/model/AtribuicaoEntrega.java
+++ b/src/main/java/com/unifood/entregador/model/AtribuicaoEntrega.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import com.unifood.entregador.model.StatusEntrega;
+
 import java.time.LocalDateTime;
 
 @Entity
@@ -20,7 +22,9 @@ public class AtribuicaoEntrega {
 
     private String orderId;
     private Long entregadorId;
-    private String status;
+
+    @Enumerated(EnumType.STRING)
+    private StatusEntrega status;
 
     private LocalDateTime atribuidoEm;
     private LocalDateTime atualizadoEm;
@@ -30,7 +34,7 @@ public class AtribuicaoEntrega {
         this.atribuidoEm = LocalDateTime.now();
         this.atualizadoEm = LocalDateTime.now();
         if (this.status == null) {
-            this.status = "PENDENTE";
+            this.status = StatusEntrega.PENDENTE;
         }
     }
 

--- a/src/main/java/com/unifood/entregador/model/StatusEntrega.java
+++ b/src/main/java/com/unifood/entregador/model/StatusEntrega.java
@@ -1,0 +1,7 @@
+package com.unifood.entregador.model;
+
+public enum StatusEntrega {
+    PENDENTE,
+    EM_ROTA,
+    ENTREGUE
+}

--- a/src/main/java/com/unifood/entregador/repository/AtribuicaoEntregaRepository.java
+++ b/src/main/java/com/unifood/entregador/repository/AtribuicaoEntregaRepository.java
@@ -1,6 +1,7 @@
 package com.unifood.entregador.repository;
 
 import com.unifood.entregador.model.AtribuicaoEntrega;
+import com.unifood.entregador.model.StatusEntrega;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface AtribuicaoEntregaRepository extends JpaRepository<AtribuicaoEntrega, Long> {
-    List<AtribuicaoEntrega> findByEntregadorIdAndStatusNot(Long entregadorId, String status);
+    List<AtribuicaoEntrega> findByEntregadorIdAndStatusNot(Long entregadorId, StatusEntrega status);
 }

--- a/src/main/java/com/unifood/entregador/service/EntregaService.java
+++ b/src/main/java/com/unifood/entregador/service/EntregaService.java
@@ -2,6 +2,7 @@ package com.unifood.entregador.service;
 
 import com.unifood.entregador.model.AtribuicaoEntrega;
 import com.unifood.entregador.model.Entregador;
+import com.unifood.entregador.model.StatusEntrega;
 import com.unifood.entregador.repository.AtribuicaoEntregaRepository;
 import com.unifood.entregador.repository.EntregadorRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -38,15 +39,15 @@ public class EntregaService {
     }
 
     @Transactional
-    public AtribuicaoEntrega atualizarStatusEntrega(Long entregaId, String novoStatus) {
+    public AtribuicaoEntrega atualizarStatusEntrega(Long entregaId, StatusEntrega novoStatus) {
         AtribuicaoEntrega atrib = atribuicaoRepository.findById(entregaId)
                 .orElseThrow(() -> new EntityNotFoundException("Atribui\u00e7\u00e3o n\u00e3o encontrada: " + entregaId));
 
-        if ("EM_ROTA".equals(novoStatus)) {
-            atrib.setStatus("EM_ROTA");
+        if (novoStatus == StatusEntrega.EM_ROTA) {
+            atrib.setStatus(StatusEntrega.EM_ROTA);
             atribuicaoRepository.save(atrib);
-        } else if ("ENTREGUE".equals(novoStatus)) {
-            atrib.setStatus("ENTREGUE");
+        } else if (novoStatus == StatusEntrega.ENTREGUE) {
+            atrib.setStatus(StatusEntrega.ENTREGUE);
             atribuicaoRepository.save(atrib);
 
             Entregador entregador = entregadorRepository.findById(atrib.getEntregadorId())
@@ -63,6 +64,6 @@ public class EntregaService {
         if (!entregadorRepository.existsById(entregadorId)) {
             throw new EntityNotFoundException("Entregador n\u00e3o encontrado: " + entregadorId);
         }
-        return atribuicaoRepository.findByEntregadorIdAndStatusNot(entregadorId, "ENTREGUE");
+        return atribuicaoRepository.findByEntregadorIdAndStatusNot(entregadorId, StatusEntrega.ENTREGUE);
     }
 }


### PR DESCRIPTION
## Summary
- add `StatusEntrega` enum for delivery status values
- store `StatusEntrega` in `AtribuicaoEntrega` using `@Enumerated(EnumType.STRING)`
- update repository method and service logic to use enum
- adjust DTOs to expose the enum instead of string

## Testing
- `mvn -q test` *(fails: wget unable to fetch maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68424de003508320b42ca94dcc37bc08