### PR TITLE
Fix repository bean loading

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=entregador-service
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
 logging.level.org.springframework.security=DEBUG
 server.port=8081
 spring.config.import=optional:application-secret.properties


### PR DESCRIPTION
## Summary
- remove DataSource auto-configuration exclusion so JPA repositories load

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_684250130810832095d74aeec606b65f