### PR TITLE
Ensure new delivery assignments start pending

### DIFF
--- a/src/main/java/com/unifood/entregador/service/EntregaService.java
+++ b/src/main/java/com/unifood/entregador/service/EntregaService.java
@@ -37,6 +37,7 @@ public class EntregaService {
         AtribuicaoEntrega atrib = new AtribuicaoEntrega();
         atrib.setOrderId(orderId);
         atrib.setEntregadorId(entregador.getId());
+        atrib.aoCriar();
         AtribuicaoEntrega salva = atribuicaoRepository.save(atrib);
         return salva;
     }


### PR DESCRIPTION
## Summary
- call `aoCriar()` when assigning deliveries so new assignments default to `PENDENTE`
- remove redundant `EntregaServiceTests`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844e764641883208ae06a843b6e2247