### PR TITLE
Integrate entregador-service with other microservices

### DIFF
--- a/src/main/java/com/unifood/entregador/EntregadorServiceApplication.java
+++ b/src/main/java/com/unifood/entregador/EntregadorServiceApplication.java
@@ -2,10 +2,18 @@ package com.unifood.entregador;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class EntregadorServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(EntregadorServiceApplication.class, args);
+    }
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
     }
 }

--- a/src/main/java/com/unifood/entregador/client/ClienteClient.java
+++ b/src/main/java/com/unifood/entregador/client/ClienteClient.java
@@ -1,0 +1,47 @@
+package com.unifood.entregador.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class ClienteClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${cliente.service.url}")
+    private String clienteServiceUrl;
+
+    public ClienteClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public String buscarNomeCliente(String clienteId) {
+        String url = String.format("%s/api/clientes/%s", clienteServiceUrl, clienteId);
+        ResponseEntity<ClienteResponse> response = restTemplate.getForEntity(url, ClienteResponse.class);
+        ClienteResponse body = response.getBody();
+        return body != null ? body.getNome() : null;
+    }
+
+    public static class ClienteResponse {
+        private String id;
+        private String nome;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getNome() {
+            return nome;
+        }
+
+        public void setNome(String nome) {
+            this.nome = nome;
+        }
+    }
+}

--- a/src/main/java/com/unifood/entregador/client/PedidoClient.java
+++ b/src/main/java/com/unifood/entregador/client/PedidoClient.java
@@ -1,0 +1,24 @@
+package com.unifood.entregador.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class PedidoClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${pedido.service.url}")
+    private String pedidoServiceUrl;
+
+    public PedidoClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public void associarEntregador(String pedidoId, String entregadorId) throws RestClientException {
+        String url = String.format("%s/api/pedidos/%s/entregador/%s", pedidoServiceUrl, pedidoId, entregadorId);
+        restTemplate.put(url, null);
+    }
+}

--- a/src/main/java/com/unifood/entregador/client/RestauranteClient.java
+++ b/src/main/java/com/unifood/entregador/client/RestauranteClient.java
@@ -1,0 +1,48 @@
+package com.unifood.entregador.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class RestauranteClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${restaurante.service.url}")
+    private String restauranteServiceUrl;
+
+    public RestauranteClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public List<ItemCardapioResponse> listarItensCardapio() {
+        String url = restauranteServiceUrl + "/itensCardapio";
+        ResponseEntity<ItemCardapioResponse[]> response = restTemplate.getForEntity(url, ItemCardapioResponse[].class);
+        ItemCardapioResponse[] body = response.getBody();
+        return body != null ? Arrays.asList(body) : List.of();
+    }
+
+    public static class ItemCardapioResponse {
+        private String id;
+        private String nome;
+        private String descricao;
+        private Double preco;
+        private String restauranteId;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+        public String getNome() { return nome; }
+        public void setNome(String nome) { this.nome = nome; }
+        public String getDescricao() { return descricao; }
+        public void setDescricao(String descricao) { this.descricao = descricao; }
+        public Double getPreco() { return preco; }
+        public void setPreco(Double preco) { this.preco = preco; }
+        public String getRestauranteId() { return restauranteId; }
+        public void setRestauranteId(String restauranteId) { this.restauranteId = restauranteId; }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,8 @@
 spring.application.name=entregador-service
 server.port=8081
 spring.config.import=optional:application-secret.properties
+
+# URLs dos microservicos externos
+pedido.service.url=https://pedido-backend-production.up.railway.app
+cliente.service.url=https://microservicocliente-production.up.railway.app
+restaurante.service.url=https://restaurante-production-7756.up.railway.app


### PR DESCRIPTION
## Summary
- create RestTemplate bean
- add client classes for Pedido, Cliente and Restaurante services
- integrate `EntregaService` with Pedido service when assigning deliveries
- configure URLs of external services

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6844ede43e148320bfb45d4c60091336