### PR TITLE
Add deliverer assignment with order price

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Microserviço responsável por gerenciar entregadores e atribuições de entrega
 - `GET /api/entregadores/disponiveis` – lista entregadores disponíveis
 - `PUT /api/entregadores/{id}/status?disponivel={true|false}` – atualiza disponibilidade
 - `GET /api/entregadores/{id}` – busca entregador por ID
+- `POST /api/entregadores/assign/{orderId}/{valorOrderId}` – atribui aleatoriamente um entregador ao pedido informando também o valor do pedido
 - `POST /api/deliveries/assign` – atribui entregador ao pedido
 - `PUT /api/deliveries/{entregaId}/status` – atualiza status da entrega
 - `GET /api/deliveries/deliverer/{entregadorId}/assignments` – lista entregas pendentes para um entregador

--- a/src/main/java/com/unifood/entregador/controller/EntregaController.java
+++ b/src/main/java/com/unifood/entregador/controller/EntregaController.java
@@ -29,6 +29,8 @@ public class EntregaController {
             AtribuirEntregaResponse resp = new AtribuirEntregaResponse(
                     atrib.getId(),
                     atrib.getEntregadorId(),
+                    atrib.getOrderId(),
+                    atrib.getValorOrderId(),
                     atrib.getStatus()
             );
             return ResponseEntity.ok(resp);

--- a/src/main/java/com/unifood/entregador/controller/EntregadorController.java
+++ b/src/main/java/com/unifood/entregador/controller/EntregadorController.java
@@ -1,7 +1,10 @@
 package com.unifood.entregador.controller;
 
+import com.unifood.entregador.dto.AtribuirEntregaResponse;
 import com.unifood.entregador.dto.EntregadorDTO;
+import com.unifood.entregador.model.AtribuicaoEntrega;
 import com.unifood.entregador.model.Entregador;
+import com.unifood.entregador.service.EntregaService;
 import com.unifood.entregador.service.EntregadorService;
 import com.unifood.entregador.exception.ResourceNotFoundException;
 import jakarta.validation.Valid;
@@ -18,6 +21,9 @@ public class EntregadorController {
 
     @Autowired
     private EntregadorService entregadorService;
+
+    @Autowired
+    private EntregaService entregaService;
 
     @PostMapping
     public ResponseEntity<Entregador> cadastrarEntregador(@Valid @RequestBody EntregadorDTO dto) {
@@ -63,6 +69,25 @@ public class EntregadorController {
             return ResponseEntity.ok(e);
         } catch (ResourceNotFoundException ex) {
             return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/assign/{orderId}/{valorOrderId}")
+    public ResponseEntity<AtribuirEntregaResponse> atribuirAleatorio(
+            @PathVariable String orderId,
+            @PathVariable String valorOrderId) {
+        try {
+            AtribuicaoEntrega atrib = entregaService.atribuirEntregadorAoPedido(orderId, valorOrderId);
+            AtribuirEntregaResponse resp = new AtribuirEntregaResponse(
+                    atrib.getId(),
+                    atrib.getEntregadorId(),
+                    atrib.getOrderId(),
+                    atrib.getValorOrderId(),
+                    atrib.getStatus()
+            );
+            return ResponseEntity.ok(resp);
+        } catch (IllegalStateException ex) {
+            return ResponseEntity.status(503).build();
         }
     }
 }

--- a/src/main/java/com/unifood/entregador/dto/AtribuirEntregaResponse.java
+++ b/src/main/java/com/unifood/entregador/dto/AtribuirEntregaResponse.java
@@ -6,11 +6,15 @@ import com.unifood.entregador.model.StatusEntrega;
 public class AtribuirEntregaResponse {
     private String entregaId;
     private String entregadorId;
+    private String orderId;
+    private String valorOrderId;
     private StatusEntrega status;
 
-    public AtribuirEntregaResponse(String entregaId, String entregadorId, StatusEntrega status) {
+    public AtribuirEntregaResponse(String entregaId, String entregadorId, String orderId, String valorOrderId, StatusEntrega status) {
         this.entregaId = entregaId;
         this.entregadorId = entregadorId;
+        this.orderId = orderId;
+        this.valorOrderId = valorOrderId;
         this.status = status;
     }
 
@@ -28,6 +32,22 @@ public class AtribuirEntregaResponse {
 
     public void setEntregadorId(String entregadorId) {
         this.entregadorId = entregadorId;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public String getValorOrderId() {
+        return valorOrderId;
+    }
+
+    public void setValorOrderId(String valorOrderId) {
+        this.valorOrderId = valorOrderId;
     }
 
     public StatusEntrega getStatus() {

--- a/src/main/java/com/unifood/entregador/model/AtribuicaoEntrega.java
+++ b/src/main/java/com/unifood/entregador/model/AtribuicaoEntrega.java
@@ -14,6 +14,7 @@ public class AtribuicaoEntrega {
     private String id;
 
     private String orderId;
+    private String valorOrderId;
     private String entregadorId;
 
     private StatusEntrega status;
@@ -41,6 +42,14 @@ public class AtribuicaoEntrega {
 
     public void setOrderId(String orderId) {
         this.orderId = orderId;
+    }
+
+    public String getValorOrderId() {
+        return valorOrderId;
+    }
+
+    public void setValorOrderId(String valorOrderId) {
+        this.valorOrderId = valorOrderId;
     }
 
     public String getEntregadorId() {

--- a/src/main/java/com/unifood/entregador/service/EntregaService.java
+++ b/src/main/java/com/unifood/entregador/service/EntregaService.java
@@ -29,16 +29,22 @@ public class EntregaService {
     }
 
     public AtribuicaoEntrega atribuirEntregadorAoPedido(String orderId) {
-        Entregador entregador = entregadorRepository.findByDisponivelTrue()
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Nenhum entregador disponível"));
+        return atribuirEntregadorAoPedido(orderId, null);
+    }
+
+    public AtribuicaoEntrega atribuirEntregadorAoPedido(String orderId, String valorOrderId) {
+        List<Entregador> disponiveis = entregadorRepository.findByDisponivelTrue();
+        if (disponiveis.isEmpty()) {
+            throw new IllegalStateException("Nenhum entregador disponível");
+        }
+        Entregador entregador = disponiveis.get(new java.util.Random().nextInt(disponiveis.size()));
 
         entregador.setDisponivel(false);
         entregadorRepository.save(entregador);
 
         AtribuicaoEntrega atrib = new AtribuicaoEntrega();
         atrib.setOrderId(orderId);
+        atrib.setValorOrderId(valorOrderId);
         atrib.setEntregadorId(entregador.getId());
         atrib.aoCriar();
         AtribuicaoEntrega salva = atribuicaoRepository.save(atrib);


### PR DESCRIPTION
## Summary
- include `valorOrderId` in `AtribuicaoEntrega`
- return all ids in `AtribuirEntregaResponse`
- overload service to accept orderId and valorOrderId
- expose POST `/api/entregadores/assign/{orderId}/{valorOrderId}`
- document new endpoint

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68452dfab45083208e16e009af7c170f