### PR TITLE
Add endpoint for active deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - `GET /api/entregadores/{id}` – busca entregador por ID  
 - `POST /api/entregadores/assign/{orderId}/{valorOrderId}` – atribui aleatoriamente um entregador ao pedido informando também o valor do pedido  
 - `POST /api/deliveries/assign` – atribui entregador ao pedido  
-- `PUT /api/deliveries/{entregaId}/status` – atualiza status da entrega  
+- `PUT /api/deliveries/{entregaId}/status` – atualiza status da entrega
 - `GET /api/deliveries/deliverer/{entregadorId}/assignments` – lista entregas em rota para um entregador
+- `GET /api/deliveries/deliverer/active` – lista todas as entregas ativas
 

--- a/src/main/java/com/unifood/entregador/controller/EntregaController.java
+++ b/src/main/java/com/unifood/entregador/controller/EntregaController.java
@@ -62,4 +62,10 @@ public class EntregaController {
             return ResponseEntity.notFound().build();
         }
     }
+
+    @GetMapping("/deliverer/active")
+    public ResponseEntity<List<AtribuicaoEntrega>> listarEntregasAtivas() {
+        List<AtribuicaoEntrega> lista = entregaService.listarEntregasAtivas();
+        return ResponseEntity.ok(lista);
+    }
 }

--- a/src/main/java/com/unifood/entregador/repository/AtribuicaoEntregaRepository.java
+++ b/src/main/java/com/unifood/entregador/repository/AtribuicaoEntregaRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface AtribuicaoEntregaRepository extends MongoRepository<AtribuicaoEntrega, String> {
     List<AtribuicaoEntrega> findByEntregadorIdAndStatusNot(String entregadorId, StatusEntrega status);
+    List<AtribuicaoEntrega> findByStatusNot(StatusEntrega status);
 }

--- a/src/main/java/com/unifood/entregador/service/EntregaService.java
+++ b/src/main/java/com/unifood/entregador/service/EntregaService.java
@@ -70,4 +70,8 @@ public class EntregaService {
         }
         return atribuicaoRepository.findByEntregadorIdAndStatusNot(entregadorId, StatusEntrega.ENTREGUE);
     }
+
+    public List<AtribuicaoEntrega> listarEntregasAtivas() {
+        return atribuicaoRepository.findByStatusNot(StatusEntrega.ENTREGUE);
+    }
 }


### PR DESCRIPTION
## Summary
- expose a new `/deliverer/active` endpoint that returns all active deliveries
- document the new route

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6846121ba15c8320ab79f726061badb4